### PR TITLE
KnownDirectives tests ported from graphql-js

### DIFF
--- a/tests/core_validation/test_known_directives.py
+++ b/tests/core_validation/test_known_directives.py
@@ -1,0 +1,104 @@
+import pytest
+
+from graphql.core.language.location import SourceLocation
+from graphql.core.validation.rules import KnownDirectives
+from utils import expect_passes_rule, expect_fails_rule
+
+
+def unknown_directive(directive_name, line, column):
+    return {
+        'message': KnownDirectives.message(directive_name),
+        'locations': [SourceLocation(line, column)]
+    }
+
+
+def misplaced_directive(directive_name, placement, line, column):
+    return {
+        'message': KnownDirectives.misplaced_directive_message(directive_name,
+                                                               placement),
+        'locations': [SourceLocation(line, column)]
+    }
+
+
+def test_with_no_directives():
+    expect_passes_rule(KnownDirectives, '''
+      query Foo {
+        name
+        ...Frag
+      }
+
+      fragment Frag on Dog {
+        name
+      }
+    ''')
+
+
+def test_with_known_directives():
+    expect_passes_rule(KnownDirectives, '''
+      {
+        dog @include(if: true) {
+          name
+        }
+        human @skip(if: false) {
+          name
+        }
+      }
+    ''')
+
+
+@pytest.mark.skipif(not hasattr(KnownDirectives, "message"),
+                    reason=("KnownDirectives.message has not yet been "
+                            "implemented"))
+def test_with_unknown_directive():
+    expect_fails_rule(KnownDirectives, '''
+      {
+        dog @unknown(directive: "value") {
+          name
+        }
+      }
+    ''', [unknown_directive('unknown', 3, 13)])
+
+
+@pytest.mark.skipif(not hasattr(KnownDirectives, "message"),
+                    reason=("KnownDirectives.message has not yet been "
+                            "implemented"))
+def test_with_many_unknown_directives():
+    expect_fails_rule(KnownDirectives, '''
+      {
+        dog @unknown(directive: "value") {
+          name
+        }
+        human @unknown(directive: "value") {
+          name
+          pets @unknown(directive: "value") {
+            name
+          }
+        }
+      }
+    ''', [unknown_directive('unknown', 3, 13),
+          unknown_directive('unknown', 6, 15),
+          unknown_directive('unknown', 8, 16)])
+
+
+def test_with_well_placed_directives():
+    expect_passes_rule(KnownDirectives, '''
+      query Foo {
+        name @include(if: true)
+        ...Frag @include(if: true)
+        skippedField @skip(if: true)
+        ...SkippedFrag @skip(if: true)
+      }
+    ''')
+
+
+@pytest.mark.skipif(not hasattr(KnownDirectives,
+                                "misplaced_directive_message"),
+                    reason=("KnownDirectives.misplaced_directive_message has "
+                            "not yet been implemented"))
+def test_with_misplaced_directives():
+    expect_fails_rule(KnownDirectives, '''
+      query Foo @include(if: true) {
+        name
+        ...Frag
+      }
+    ''', [misplaced_directive('include', 'operation', 2, 17)])


### PR DESCRIPTION
Skips tests requiring parts of the API that have not yet been implemented.