### PR TITLE
Implement KnownFragmentNames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ docs/_build/
 # PyBuilder
 target/
 
+# IntelliJ
+.idea

--- a/graphql/core/validation/__init__.py
+++ b/graphql/core/validation/__init__.py
@@ -118,7 +118,7 @@ class ValidationContext(object):
         fragments = self._fragments
         if fragments is None:
             self._fragments = fragments = {}
-            for statement in self.get_document().definitions:
+            for statement in self.get_ast().definitions:
                 if isinstance(statement, FragmentDefinition):
                     fragments[statement.name.value] = statement
         return fragments[name]

--- a/graphql/core/validation/rules.py
+++ b/graphql/core/validation/rules.py
@@ -167,7 +167,19 @@ class UniqueFragmentNames(ValidationRule):
 
 
 class KnownFragmentNames(ValidationRule):
-    pass
+    def enter_FragmentSpread(self, node, *args):
+        fragment_name = node.name.value
+        try:
+            self.context.get_fragment(fragment_name)
+        except KeyError:
+            return GraphQLError(
+                self.unknown_fragment_message(fragment_name),
+                [node.name]
+            )
+
+    @staticmethod
+    def unknown_fragment_message(fragment_name):
+        return 'Unknown fragment "{}".'.format(fragment_name)
 
 
 class NoUnusedFragments(ValidationRule):

--- a/tests/core_validation/test_known_fragment_names.py
+++ b/tests/core_validation/test_known_fragment_names.py
@@ -1,0 +1,55 @@
+from graphql.core.language.location import SourceLocation
+from graphql.core.validation.rules import KnownFragmentNames
+from utils import expect_passes_rule, expect_fails_rule
+
+
+def undefined_fragment(fragment_name, line, column):
+    return {
+        'message': KnownFragmentNames.unknown_fragment_message(fragment_name),
+        'locations': [SourceLocation(line, column)]
+    }
+
+
+def test_known_fragment_names_are_valid():
+    expect_passes_rule(KnownFragmentNames, '''
+    {
+        human(id: 4) {
+            ...HumanFields1
+            ... on Human {
+                ...HumanFields2
+            }
+        }
+    }
+    fragment HumanFields1 on Human {
+        name
+        ...HumanFields3
+    }
+    fragment HumanFields2 on Human {
+        name
+    }
+    fragment HumanFields3 on Human {
+        name
+    }
+    ''')
+
+
+def test_unknown_fragment_names_are_invalid():
+    expect_fails_rule(KnownFragmentNames, '''
+    {
+        human(id: 4) {
+            ...UnknownFragment1
+            ... on Human {
+                ...UnknownFragment2
+            }
+        }
+    }
+    fragment HumanFields on Human {
+        name
+        ...UnknownFragment3
+    }
+    ''', [
+        undefined_fragment('UnknownFragment1', 4, 16),
+        undefined_fragment('UnknownFragment2', 6, 20),
+        undefined_fragment('UnknownFragment3', 12, 12),
+
+    ])


### PR DESCRIPTION
- implement unit tests
- fix ValidationContext.get_fragment to use self.get_ast() instead of self.get_document()

#6